### PR TITLE
feat(dynamodb-mcp-server): Adding tools to analyze source database for DynamoDB Data Modeling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -215,7 +215,7 @@
         "filename": "src/dynamodb-mcp-server/README.md",
         "hashed_secret": "865cb07920436ba6bc91ce67b104dbbf14797f38",
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 125,
         "is_secret": false
       }
     ],
@@ -822,5 +822,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-18T17:45:57Z"
+  "generated_at": "2025-09-23T11:41:36Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -209,6 +209,16 @@
         "is_secret": false
       }
     ],
+    "src/dynamodb-mcp-server/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/dynamodb-mcp-server/README.md",
+        "hashed_secret": "865cb07920436ba6bc91ce67b104dbbf14797f38",
+        "is_verified": false,
+        "line_number": 150,
+        "is_secret": false
+      }
+    ],
     "src/ecs-mcp-server/tests/conftest.py": [
       {
         "type": "Base64 High Entropy String",
@@ -812,5 +822,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-14T17:41:02Z"
+  "generated_at": "2025-09-18T17:45:57Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -215,7 +215,7 @@
         "filename": "src/dynamodb-mcp-server/README.md",
         "hashed_secret": "865cb07920436ba6bc91ce67b104dbbf14797f38",
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 128,
         "is_secret": false
       }
     ],
@@ -822,5 +822,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-23T11:41:36Z"
+  "generated_at": "2025-09-23T17:13:44Z"
 }

--- a/src/dynamodb-mcp-server/README.md
+++ b/src/dynamodb-mcp-server/README.md
@@ -2,16 +2,15 @@
 
 The official MCP Server for interacting with AWS DynamoDB
 
-This comprehensive server provides both operational DynamoDB management and expert design guidance, featuring 30+ operational tools for managing DynamoDB tables, items, indexes, backups, and more, expert data modeling guidance and also MySQL query capabilities for database analysis and migration planning.
+This comprehensive server provides both operational DynamoDB management and expert design guidance, featuring 30+ operational tools for managing DynamoDB tables, items, indexes, backups, and more, expert data modeling guidance and also MySQL query capabilities for source database analysis to design DynamoDB Data Modeling.
 
 ## Available MCP Tools
 
 ### Design & Modeling
 - `dynamodb_data_modeling` - Retrieves the complete DynamoDB Data Modeling Expert prompt
 
-### Source Database Analysis for Migration Planning
-- `analyze_access_patterns` - Analyze database access patterns and traffic for DynamoDB migration planning
-- `analyze_schema` - Analyze database schema structure for DynamoDB migration planning
+### Source Database Analysis for DynamoDB Data Modeling
+- `analyze_source_db` - Execute predefined SQL queries against source database for comprehensive analysis
 
 ### Table Operations
 - `create_table` - Creates a new DynamoDB table with optional secondary indexes
@@ -67,7 +66,7 @@ All tools support an optional `region_name` parameter to specify which AWS regio
 
 ## Source Database Integration
 
-The DynamoDB MCP server includes source database integration for database analysis and migration planning.
+The DynamoDB MCP server includes source database integration for database analysis and design DynamoDB Data Modeling.
 Currently supports Aurora MySQL with additional database support planned for future releases.
 
 ### MySQL Environment Variables
@@ -88,37 +87,13 @@ Currently supports Aurora MySQL with additional database support planned for fut
 
 Add these environment variables to DynamoDB MCP Server configuration to enable MySQL integration:
 
-- `MYSQL_CLUSTER_ARN`: RDS / Aurora MySQL cluster ARN
+- `MYSQL_CLUSTER_ARN`: Aurora MySQL cluster ARN
 - `MYSQL_SECRET_ARN`: AWS Secrets Manager secret ARN with database credentials
 - `MYSQL_DATABASE`: Database name to connect to
 - `MYSQL_AWS_REGION`: AWS region for MySQL cluster (optional, defaults to AWS_REGION)
 - `MYSQL_READONLY`: optional (default: "true")
 
-**Note**: MySQL source database connection is established only when you set these environment variables in config and enables you to run the migration analysis tools such as `analyze_access_patterns` and `analyze_schema`.
-
-## Source-DB to DynamoDB Data Modeling Workflow
-
-To design a DynamoDB data model based on your existing MySQL database, follow this workflow using the analysis tools:
-
-### 1. Analyze MySQL Access Patterns
-```
-Analyze access patterns for my MySQL database "employees" over the last 30 days
-```
-This analyzes query patterns, RPS, and identifies hot access patterns from MySQL Performance Schema.
-
-### 2. Analyze MySQL Schema Structure
-```
-Analyze the schema structure of my MySQL database "employees"
-```
-This examines table structures, relationships, indexes, and data distribution.
-
-### 3. Design DynamoDB Schema
-```
-Help me design a DynamoDB data model using the analysis results
-```
-This invoke the DynamoDB data modeling tool to design your schema using the analysis from step 1 and 2.
-
-**Note**: Execute these steps manually in sequence for complete data modeling analysis.
+**Note**: MySQL source database connection is established only when you set these environment variables in config and enables you to run the analysis tool `analyze_source_db`.
 
 ## Prerequisites
 

--- a/src/dynamodb-mcp-server/README.md
+++ b/src/dynamodb-mcp-server/README.md
@@ -69,8 +69,6 @@ All tools support an optional `region_name` parameter to specify which AWS regio
 The DynamoDB MCP server includes source database integration for database analysis and design DynamoDB Data Modeling.
 Currently supports Aurora MySQL with additional database support planned for future releases.
 
-### MySQL Environment Variables
-
 **Prerequisites for MySQL Integration:**
 1. Aurora MySQL Cluster with MySQL username and password stored in AWS Secrets Manager
 2. Enable RDS Data API for your Aurora MySQL Cluster
@@ -85,6 +83,10 @@ Currently supports Aurora MySQL with additional database support planned for fut
    - Configure AWS credentials with `aws configure` or environment variables
    - AWS profile with permissions to access RDS Data API and AWS Secrets Manager
 
+Recommendation: Run this database analysis tool 'analyze_source_db' in a non-production environment with replicated traffic patterns to ensure accurate results while protecting production systems and sensitive data.
+
+### MySQL Environment Variables
+
 Add these environment variables to DynamoDB MCP Server configuration to enable MySQL integration:
 
 - `MYSQL_CLUSTER_ARN`: Aurora MySQL cluster ARN
@@ -92,6 +94,7 @@ Add these environment variables to DynamoDB MCP Server configuration to enable M
 - `MYSQL_DATABASE`: Database name to connect to
 - `MYSQL_AWS_REGION`: AWS region for MySQL cluster (optional, defaults to AWS_REGION)
 - `MYSQL_READONLY`: optional (default: "true")
+- `MYSQL_MAX_QUERY_RESULTS`: Maximum number of rows returned per analysis query (optional, default: "500")
 
 **Note**: MySQL source database connection is established only when you set these environment variables in config and enables you to run the analysis tool `analyze_source_db`.
 

--- a/src/dynamodb-mcp-server/awslabs/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/__init__.py
@@ -14,3 +14,6 @@
 
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
+
+# Extend namespace to include installed packages
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/src/dynamodb-mcp-server/awslabs/__init__.py
+++ b/src/dynamodb-mcp-server/awslabs/__init__.py
@@ -15,5 +15,22 @@
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
 
+# Namespace Package Configuration
+#
+# This line resolves namespace conflicts when multiple packages share the 'awslabs' namespace prefix.
+# Without this configuration, test suites fail and build issues occur because Python cannot properly
+# resolve which package owns the 'awslabs' namespace when both 'awslabs.dynamodb-mcp-server' and
+# 'awslabs.mysql-mcp-server' are installed in the same environment.
+#
+# The extend_path() function implements PEP 420 namespace packages, allowing multiple distributions
+# to contribute modules to the same namespace. This ensures that:
+# 1. Both DynamoDB and MySQL MCP servers can coexist in the same Python environment
+# 2. Import statements like 'from awslabs.dynamodb_mcp_server import ...' work correctly
+# 3. Test discovery and execution functions properly across both packages
+# 4. Build processes complete successfully without namespace collision errors
+#
+# This is the standard solution for namespace packages in Python and is required for proper
+# multi-package namespace support in the awslabs ecosystem.
+
 # Extend namespace to include installed packages
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/database_analysis_queries.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/database_analysis_queries.py
@@ -12,28 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""MySQL Analysis SQL Query Resources for DynamoDB Migration."""
+"""Source Database Analysis SQL Query Resources for DynamoDB Data Modeling."""
 
 from typing import Any, Dict
 
 
-# SQL Query Templates as Resources
+# SQL Query Templates for MySQL
 mysql_analysis_queries = {
     'database_identification': {
         'name': 'Database Identification',
-        'description': 'Identifies the currently configured database',
+        'description': 'Identifies the currently configured database connection to confirm which database will be analyzed',
         'sql': 'SELECT DATABASE() as configured_database;',
         'parameters': [],
     },
     'performance_schema_check': {
         'name': 'Performance Schema Status Check',
-        'description': 'Verifies if Performance Schema is enabled for analysis',
+        'description': 'Verifies if MySQL Performance Schema is enabled, which is required for query pattern analysis and RPS calculations',
         'sql': "SHOW VARIABLES LIKE 'performance_schema';",
         'parameters': [],
     },
     'pattern_analysis': {
         'name': 'Query Pattern Analysis',
-        'description': 'Analyzes query patterns from Performance Schema with RPS calculation',
+        'description': 'Analyzes normalized query patterns from Performance Schema over specified time period, calculating RPS, execution times, scan patterns, and complexity classification for DynamoDB Data Modeling',
         'sql': """SELECT
   DIGEST_TEXT as query_pattern,
   COUNT_STAR as frequency,
@@ -83,7 +83,7 @@ ORDER BY frequency DESC;""",
     },
     'table_analysis': {
         'name': 'Table Structure Analysis',
-        'description': 'Analyzes table sizes, row counts, and basic structure',
+        'description': 'Analyzes table sizes, row counts, data/index storage usage, column counts, and foreign key relationships to understand database structure and identify largest tables',
         'sql': """SELECT
   TABLE_NAME,
   TABLE_ROWS,
@@ -100,7 +100,7 @@ ORDER BY TABLE_ROWS DESC;""",
     },
     'column_analysis': {
         'name': 'Column Information Analysis',
-        'description': 'Detailed column structure and data types',
+        'description': 'Detailed analysis of column structures, data types, nullability, keys, and defaults to understand attribute patterns and identify potential DynamoDB attribute mappings and data type conversions',
         'sql': """SELECT
   TABLE_NAME,
   COLUMN_NAME,
@@ -116,7 +116,7 @@ ORDER BY TABLE_NAME, ORDINAL_POSITION;""",
     },
     'index_analysis': {
         'name': 'Index Statistics Analysis',
-        'description': 'Index structure and composition analysis',
+        'description': 'Analyzes index structures, compositions, and uniqueness constraints to identify access patterns and determine optimal DynamoDB key design and Global Secondary Index requirements',
         'sql': """SELECT
   TABLE_NAME,
   INDEX_NAME,
@@ -130,7 +130,7 @@ ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX;""",
     },
     'foreign_key_analysis': {
         'name': 'Foreign Key Relationship Analysis',
-        'description': 'Foreign key constraints and relationship cardinality',
+        'description': 'Analyzes foreign key constraints, referential integrity rules, and relationship cardinalities to understand entity relationships and design appropriate DynamoDB item collections and access patterns',
         'sql': """SELECT
   kcu.CONSTRAINT_NAME,
   kcu.TABLE_NAME as child_table,
@@ -160,7 +160,7 @@ ORDER BY kcu.TABLE_NAME, kcu.COLUMN_NAME;""",
     },
     'database_objects': {
         'name': 'Database Objects Summary',
-        'description': 'Summary of triggers, procedures, and functions',
+        'description': 'Comprehensive inventory of database objects including tables, triggers, stored procedures, and functions to identify complexity and potential application logic that needs to be redesigned for DynamoDB',
         'sql': """SELECT
   'Tables' as object_type,
   COUNT(*) as count,
@@ -194,7 +194,7 @@ AND ROUTINE_TYPE = 'FUNCTION';""",
     },
     'rps_calculation': {
         'name': 'RPS and Traffic Analysis',
-        'description': 'Overall RPS calculation and traffic patterns',
+        'description': 'Calculates requests per second (RPS) and analyzes traffic patterns by date/hour, read/write ratios, and query distribution to determine DynamoDB capacity requirements and identify peak usage periods for scaling planning',
         'sql': """SELECT
   DATE(LAST_SEEN) as analysis_date,
   HOUR(LAST_SEEN) as analysis_hour,

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/database_analysis_queries.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/database_analysis_queries.py
@@ -1,0 +1,245 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MySQL Analysis SQL Query Resources for DynamoDB Migration."""
+
+from typing import Any, Dict
+
+
+# SQL Query Templates as Resources
+mysql_analysis_queries = {
+    'database_identification': {
+        'name': 'Database Identification',
+        'description': 'Identifies the currently configured database',
+        'sql': 'SELECT DATABASE() as configured_database;',
+        'parameters': [],
+    },
+    'performance_schema_check': {
+        'name': 'Performance Schema Status Check',
+        'description': 'Verifies if Performance Schema is enabled for analysis',
+        'sql': "SHOW VARIABLES LIKE 'performance_schema';",
+        'parameters': [],
+    },
+    'pattern_analysis': {
+        'name': 'Query Pattern Analysis',
+        'description': 'Analyzes query patterns from Performance Schema with RPS calculation',
+        'sql': """SELECT
+  DIGEST_TEXT as query_pattern,
+  COUNT_STAR as frequency,
+  ROUND(COUNT_STAR / ({analysis_days} * 24 * 3600), 4) as calculated_rps,
+  ROUND(AVG_TIMER_WAIT/1000000000, 6) as avg_execution_time,
+  ROUND(SUM_ROWS_EXAMINED/COUNT_STAR, 1) as avg_rows_per_query,
+  SUM_SELECT_SCAN as full_table_scans,
+  SUM_SELECT_FULL_JOIN as full_joins,
+  FIRST_SEEN as first_seen,
+  LAST_SEEN as last_seen,
+  CASE
+    WHEN DIGEST_TEXT LIKE 'SELECT%FROM%WHERE%' AND DIGEST_TEXT NOT LIKE '%JOIN%' THEN 'Single Table Search'
+    WHEN DIGEST_TEXT LIKE '%JOIN%' THEN 'JOIN Query'
+    WHEN DIGEST_TEXT LIKE '%JOIN%'
+        AND (DIGEST_TEXT LIKE '%GROUP BY%' OR DIGEST_TEXT LIKE '%ORDER BY%'
+            OR DIGEST_TEXT LIKE '%HAVING%') THEN 'Complex JOIN'
+    WHEN DIGEST_TEXT REGEXP '^CALL [a-zA-Z_][a-zA-Z0-9_]*' THEN 'Stored Procedure'
+    WHEN DIGEST_TEXT LIKE 'SELECT%' THEN 'Simple SELECT'
+    ELSE 'Other'
+  END as complexity_type,
+  CASE
+    WHEN DIGEST_TEXT LIKE '%WHERE%id%=%' THEN 'Likely Primary Key'
+    WHEN DIGEST_TEXT LIKE '%WHERE%' AND DIGEST_TEXT LIKE '%=%' THEN 'Likely Indexed'
+    WHEN DIGEST_TEXT LIKE '%WHERE%' AND DIGEST_TEXT LIKE '%LIKE%' THEN 'Potential Full Scan'
+    ELSE 'Unknown Index Usage'
+  END as index_usage_hint
+FROM performance_schema.events_statements_summary_by_digest
+WHERE SCHEMA_NAME = '{target_database}'
+AND COUNT_STAR > 5
+AND LAST_SEEN >= DATE_SUB(NOW(), INTERVAL {analysis_days} DAY)
+AND DIGEST_TEXT NOT LIKE 'SET%'
+AND DIGEST_TEXT NOT LIKE 'USE %'
+AND DIGEST_TEXT NOT LIKE 'SHOW%'
+AND DIGEST_TEXT NOT LIKE '/* RDS Data API */%'
+AND DIGEST_TEXT NOT LIKE '%information_schema%'
+AND DIGEST_TEXT NOT LIKE '%performance_schema%'
+AND DIGEST_TEXT NOT LIKE '%mysql.%'
+AND DIGEST_TEXT NOT LIKE 'SELECT @@%'
+AND DIGEST_TEXT NOT LIKE '%sys.%'
+AND DIGEST_TEXT NOT LIKE 'select ?'
+AND DIGEST_TEXT NOT LIKE '%mysql.general_log%'
+AND DIGEST_TEXT NOT LIKE 'DESCRIBE %'
+AND DIGEST_TEXT NOT LIKE 'EXPLAIN %'
+AND DIGEST_TEXT NOT LIKE 'configured_database'
+ORDER BY frequency DESC;""",
+        'parameters': ['target_database', 'analysis_days'],
+    },
+    'table_analysis': {
+        'name': 'Table Structure Analysis',
+        'description': 'Analyzes table sizes, row counts, and basic structure',
+        'sql': """SELECT
+  TABLE_NAME,
+  TABLE_ROWS,
+  ROUND(DATA_LENGTH/1024/1024, 2) as datamb,
+  ROUND(INDEX_LENGTH/1024/1024, 2) as indexmb,
+  (SELECT COUNT(*) FROM information_schema.COLUMNS c WHERE c.TABLE_SCHEMA = t.TABLE_SCHEMA AND c.TABLE_NAME = t.TABLE_NAME) as columncount,
+  (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE k WHERE k.TABLE_SCHEMA = t.TABLE_SCHEMA AND k.TABLE_NAME = t.TABLE_NAME AND k.REFERENCED_TABLE_NAME IS NOT NULL) as fkcount,
+  CREATE_TIME,
+  UPDATE_TIME
+FROM information_schema.TABLES t
+WHERE TABLE_SCHEMA = '{target_database}'
+ORDER BY TABLE_ROWS DESC;""",
+        'parameters': ['target_database'],
+    },
+    'column_analysis': {
+        'name': 'Column Information Analysis',
+        'description': 'Detailed column structure and data types',
+        'sql': """SELECT
+  TABLE_NAME,
+  COLUMN_NAME,
+  COLUMN_TYPE,
+  IS_NULLABLE,
+  COLUMN_KEY,
+  COLUMN_DEFAULT,
+  EXTRA
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = '{target_database}'
+ORDER BY TABLE_NAME, ORDINAL_POSITION;""",
+        'parameters': ['target_database'],
+    },
+    'index_analysis': {
+        'name': 'Index Statistics Analysis',
+        'description': 'Index structure and composition analysis',
+        'sql': """SELECT
+  TABLE_NAME,
+  INDEX_NAME,
+  COLUMN_NAME,
+  NON_UNIQUE,
+  SEQ_IN_INDEX
+FROM information_schema.STATISTICS
+WHERE TABLE_SCHEMA = '{target_database}'
+ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX;""",
+        'parameters': ['target_database'],
+    },
+    'foreign_key_analysis': {
+        'name': 'Foreign Key Relationship Analysis',
+        'description': 'Foreign key constraints and relationship cardinality',
+        'sql': """SELECT
+  kcu.CONSTRAINT_NAME,
+  kcu.TABLE_NAME as child_table,
+  kcu.COLUMN_NAME as child_column,
+  kcu.REFERENCED_TABLE_NAME as parent_table,
+  kcu.REFERENCED_COLUMN_NAME as parent_column,
+  rc.UPDATE_RULE,
+  rc.DELETE_RULE,
+  CASE
+    WHEN EXISTS (
+      SELECT 1 FROM information_schema.STATISTICS s
+      WHERE s.TABLE_SCHEMA = '{target_database}'
+      AND s.TABLE_NAME = kcu.TABLE_NAME
+      AND s.COLUMN_NAME = kcu.COLUMN_NAME
+      AND s.NON_UNIQUE = 0
+    ) THEN '1:1 or 1:0..1'
+    ELSE '1:Many'
+  END as estimated_cardinality
+FROM information_schema.KEY_COLUMN_USAGE kcu
+LEFT JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+  ON kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+  AND kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+WHERE kcu.TABLE_SCHEMA = '{target_database}'
+  AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
+ORDER BY kcu.TABLE_NAME, kcu.COLUMN_NAME;""",
+        'parameters': ['target_database'],
+    },
+    'database_objects': {
+        'name': 'Database Objects Summary',
+        'description': 'Summary of triggers, procedures, and functions',
+        'sql': """SELECT
+  'Tables' as object_type,
+  COUNT(*) as count,
+  GROUP_CONCAT(TABLE_NAME) as names
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = '{target_database}'
+UNION ALL
+SELECT
+  'Triggers' as object_type,
+  COUNT(*) as count,
+  COALESCE(GROUP_CONCAT(TRIGGER_NAME), 'None') as names
+FROM information_schema.TRIGGERS
+WHERE TRIGGER_SCHEMA = '{target_database}'
+UNION ALL
+SELECT
+  'Stored Procedures' as object_type,
+  COUNT(*) as count,
+  COALESCE(GROUP_CONCAT(ROUTINE_NAME), 'None') as names
+FROM information_schema.ROUTINES
+WHERE ROUTINE_SCHEMA = '{target_database}'
+AND ROUTINE_TYPE = 'PROCEDURE'
+UNION ALL
+SELECT
+  'Functions' as object_type,
+  COUNT(*) as count,
+  COALESCE(GROUP_CONCAT(ROUTINE_NAME), 'None') as names
+FROM information_schema.ROUTINES
+WHERE ROUTINE_SCHEMA = '{target_database}'
+AND ROUTINE_TYPE = 'FUNCTION';""",
+        'parameters': ['target_database'],
+    },
+    'rps_calculation': {
+        'name': 'RPS and Traffic Analysis',
+        'description': 'Overall RPS calculation and traffic patterns',
+        'sql': """SELECT
+  DATE(LAST_SEEN) as analysis_date,
+  HOUR(LAST_SEEN) as analysis_hour,
+  SUM(COUNT_STAR) as total_queries,
+  SUM(COUNT_STAR) / 3600 as avg_rps_this_hour,
+  COUNT(DISTINCT DIGEST) as unique_query_patterns,
+  SUM(COUNT_STAR / ({analysis_days} * 24 * 3600)) as estimated_average_rps,
+  MAX(COUNT_STAR) as highest_pattern_frequency,
+  COUNT(DISTINCT DIGEST) as unique_query_patterns,
+  SUM(CASE WHEN DIGEST_TEXT LIKE 'SELECT%' THEN COUNT_STAR ELSE 0 END) as read_queries,
+  SUM(CASE WHEN DIGEST_TEXT NOT LIKE 'SELECT%' THEN COUNT_STAR ELSE 0 END) as write_queries
+FROM performance_schema.events_statements_summary_by_digest
+WHERE SCHEMA_NAME = '{target_database}'
+  AND LAST_SEEN >= DATE_SUB(NOW(), INTERVAL {analysis_days} DAY)
+  AND COUNT_STAR > 0
+  AND DIGEST_TEXT NOT LIKE 'SET%'
+  AND DIGEST_TEXT NOT LIKE 'USE %'
+  AND DIGEST_TEXT NOT LIKE 'SHOW%'
+  AND DIGEST_TEXT NOT LIKE '/* RDS Data API */%'
+  AND DIGEST_TEXT NOT LIKE '%information_schema%'
+  AND DIGEST_TEXT NOT LIKE '%performance_schema%'
+  AND DIGEST_TEXT NOT LIKE '%mysql.%'
+  AND DIGEST_TEXT NOT LIKE 'SELECT @@%'
+  AND DIGEST_TEXT NOT LIKE '%sys.%'
+  AND DIGEST_TEXT NOT LIKE 'select ?'
+  AND DIGEST_TEXT NOT LIKE '%mysql.general_log%'
+  AND DIGEST_TEXT NOT LIKE 'DESCRIBE %'
+  AND DIGEST_TEXT NOT LIKE 'EXPLAIN %'
+  AND DIGEST_TEXT NOT LIKE 'configured_database'
+GROUP BY DATE(LAST_SEEN), HOUR(LAST_SEEN)
+ORDER BY analysis_date DESC, analysis_hour DESC;""",
+        'parameters': ['target_database', 'analysis_days'],
+    },
+}
+
+
+def get_query_resource(query_name: str, **params) -> Dict[str, Any]:
+    """Get a SQL query resource with parameters substituted."""
+    if query_name not in mysql_analysis_queries:
+        raise ValueError(f"Query '{query_name}' not found")
+
+    query_info = mysql_analysis_queries[query_name].copy()
+
+    # Substitute parameters in SQL
+    if params:
+        query_info['sql'] = query_info['sql'].format(**params)
+
+    return query_info

--- a/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
+++ b/src/dynamodb-mcp-server/awslabs/dynamodb_mcp_server/server.py
@@ -67,7 +67,7 @@ This server provides comprehensive DynamoDB capabilities with over 30 operationa
 items, indexes, backups, and more, plus expert data modeling guidance through DynamoDB data modeling expert prompt.
 
 MySQL Integration: This server also includes MySQL query capabilities through the run_query tool, enabling database
-analysis and migration planning from MySQL to DynamoDB.
+analysis for DynamoDB DynamoDB Data Modeling.
 
 IMPORTANT: DynamoDB Attribute Value Format
 -----------------------------------------

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "typing-extensions==4.14.1",
     "strands-agents>=1.5.0",
     "dspy-ai>=2.6.27",
-    "awslabs-mysql-mcp-server>=1.0.5",
+    "awslabs-mysql-mcp-server==1.0.5",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/dynamodb-mcp-server/pyproject.toml
+++ b/src/dynamodb-mcp-server/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "pydantic==2.11.7",
     "typing-extensions==4.14.1",
     "strands-agents>=1.5.0",
-    "dspy-ai>=2.6.27"
+    "dspy-ai>=2.6.27",
+    "awslabs-mysql-mcp-server>=1.0.5",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/dynamodb-mcp-server/tests/__init__.py
+++ b/src/dynamodb-mcp-server/tests/__init__.py
@@ -1,4 +1,9 @@
-"""Tests package - sets up import path for local modules."""
+"""Tests package - sets up import path for local modules.
+
+This configures Python's import path so pytest can import awslabs.dynamodb_mcp_server
+modules during development testing before the package is installed.
+Without this, test imports would fail with ModuleNotFoundError.
+"""
 
 import sys
 import os

--- a/src/dynamodb-mcp-server/tests/__init__.py
+++ b/src/dynamodb-mcp-server/tests/__init__.py
@@ -1,0 +1,9 @@
+"""Tests package - sets up import path for local modules."""
+
+import sys
+import os
+
+# Add the project root to Python path so tests can import local modules when running pytest
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)

--- a/src/dynamodb-mcp-server/tests/conftest.py
+++ b/src/dynamodb-mcp-server/tests/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+@pytest.fixture
+def mysql_env_setup(monkeypatch):
+    """Set up MySQL environment variables for testing."""
+    monkeypatch.setenv(
+        'MYSQL_CLUSTER_ARN', 'arn:aws:rds:us-west-2:123456789012:cluster:test-cluster'
+    )
+    monkeypatch.setenv(
+        'MYSQL_SECRET_ARN', 'arn:aws:secretsmanager:us-west-2:123456789012:secret:test-secret'
+    )
+    monkeypatch.setenv('MYSQL_DATABASE', 'employees')
+    monkeypatch.setenv('AWS_REGION', 'us-west-2')
+    monkeypatch.setenv('MYSQL_AWS_REGION', 'us-west-2')
+
+
+@pytest.fixture
+def mock_mysql_functions(monkeypatch):
+    """Mock MySQL connection and query functions."""
+
+    def mock_initialize(*args, **kwargs):
+        return True
+
+    async def mock_query(*args, **kwargs):
+        return [{'id': 1, 'name': 'test'}]
+
+    monkeypatch.setattr(
+        'awslabs.dynamodb_mcp_server.server.DBConnectionSingleton.initialize', mock_initialize
+    )
+    monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_query', mock_query)

--- a/src/dynamodb-mcp-server/tests/test_dynamodb_server.py
+++ b/src/dynamodb-mcp-server/tests/test_dynamodb_server.py
@@ -3,8 +3,7 @@ import boto3
 import pytest
 import pytest_asyncio
 from awslabs.dynamodb_mcp_server.server import (
-    analyze_access_patterns,
-    analyze_schema,
+    analyze_source_db,
     create_backup,
     create_table,
     delete_item,
@@ -933,180 +932,80 @@ async def test_dynamodb_data_modeling_mcp_integration():
 
 
 @pytest.mark.asyncio
-async def test_analyze_access_patterns_success(mysql_env_setup, monkeypatch):
-    """Test successful access pattern analysis."""
+async def test_analyze_source_db_success(mysql_env_setup, monkeypatch):
+    """Test successful source database analysis."""
 
-    # Mock performance schema check and analysis results
+    # Mock successful query result for SELECT DATABASE() as configured_database;
     async def mock_mysql_run_query(sql, *args, **kwargs):
-        if 'performance_schema' in sql:
-            return [{'Variable_name': 'performance_schema', 'Value': 'ON'}]
-        elif 'pattern_analysis' in sql or 'DIGEST_TEXT' in sql:
-            return [
-                {
-                    'DIGEST_TEXT': 'SELECT * FROM employees WHERE emp_no = ?',
-                    'COUNT_STAR': 100,
-                    'calculated_rps': 0.05,
-                },
-                {
-                    'DIGEST_TEXT': 'INSERT INTO salaries VALUES (...)',
-                    'COUNT_STAR': 50,
-                    'calculated_rps': 0.025,
-                },
-            ]
-        elif 'rps_calculation' in sql or 'total_queries' in sql:
-            return [{'total_queries': 150, 'avg_rps_this_hour': 0.042}]
-        return []
+        return [{'configured_database': 'employees'}]
 
     monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_run_query', mock_mysql_run_query)
 
-    result = await analyze_access_patterns('mysql', 'employees', 30)
+    result = await analyze_source_db('mysql', 'employees', 30, 'database_identification')
 
-    assert 'Access Pattern Analysis Results:' in result
-    assert 'RPS Analysis Results:' in result
+    assert 'Query Analysis Results:' in result
+    assert 'Database Identification:' in result
     assert 'employees' in result
+    assert 'Analysis Period: 30 days' in result
 
 
 @pytest.mark.asyncio
-async def test_analyze_access_patterns_performance_schema_disabled(mysql_env_setup, monkeypatch):
-    """Test access pattern analysis when performance schema is disabled."""
+async def test_analyze_source_db_pattern_analysis(mysql_env_setup, monkeypatch):
+    """Test analyze_source_db with pattern analysis."""
 
-    # Mock performance schema disabled
+    # Mock pattern analysis result
     async def mock_mysql_run_query(sql, *args, **kwargs):
-        if 'performance_schema' in sql:
-            return [{'Variable_name': 'performance_schema', 'Value': 'OFF'}]
-        return []
+        return [
+            {
+                'query_pattern': 'SELECT * FROM employees WHERE emp_no = ?',
+                'frequency': 100,
+                'calculated_rps': 0.05,
+            },
+            {
+                'query_pattern': 'INSERT INTO salaries VALUES (...)',
+                'frequency': 50,
+                'calculated_rps': 0.025,
+            },
+        ]
 
     monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_run_query', mock_mysql_run_query)
 
-    result = await analyze_access_patterns('mysql', 'employees', 30)
+    result = await analyze_source_db('mysql', 'employees', 30, 'pattern_analysis')
 
-    assert 'MySQL Performance Schema is disabled' in result
-    assert 'Parameter groups' in result
+    assert 'Query Analysis Results:' in result
+    assert 'Query Pattern Analysis:' in result
+    assert 'Analysis Period: 30 days' in result
 
 
 @pytest.mark.asyncio
-async def test_analyze_schema_success(mysql_env_setup, monkeypatch):
-    """Test successful schema analysis."""
+async def test_analyze_source_db_invalid_query():
+    """Test analyze_source_db with invalid query name."""
+    result = await analyze_source_db('mysql', 'employees', 30, 'invalid_query')
 
-    # Mock schema analysis results
+    assert "Error: Query 'invalid_query' not found" in result
+    assert 'Available queries:' in result
+
+
+@pytest.mark.asyncio
+async def test_analyze_source_db_mysql_error(mysql_env_setup, monkeypatch):
+    """Test analyze_source_db when MySQL query fails."""
+
+    # Mock MySQL query error
     async def mock_mysql_run_query(sql, *args, **kwargs):
-        if 'TABLE_NAME' in sql and 'TABLE_ROWS' in sql:
-            return [
-                {
-                    'TABLE_NAME': 'employees',
-                    'TABLE_ROWS': 300000,
-                    'datamb': '15.2',
-                    'indexmb': '2.1',
-                },
-                {
-                    'TABLE_NAME': 'salaries',
-                    'TABLE_ROWS': 2800000,
-                    'datamb': '120.5',
-                    'indexmb': '0.0',
-                },
-            ]
-        elif 'COLUMN_NAME' in sql:
-            return [
-                {
-                    'TABLE_NAME': 'employees',
-                    'COLUMN_NAME': 'emp_no',
-                    'COLUMN_TYPE': 'int',
-                    'COLUMN_KEY': 'PRI',
-                },
-                {
-                    'TABLE_NAME': 'employees',
-                    'COLUMN_NAME': 'first_name',
-                    'COLUMN_TYPE': 'varchar(14)',
-                    'COLUMN_KEY': '',
-                },
-            ]
-        elif 'INDEX_NAME' in sql:
-            return [
-                {
-                    'TABLE_NAME': 'employees',
-                    'INDEX_NAME': 'PRIMARY',
-                    'COLUMN_NAME': 'emp_no',
-                    'NON_UNIQUE': 0,
-                }
-            ]
-        elif 'CONSTRAINT_NAME' in sql:
-            return [
-                {
-                    'CONSTRAINT_NAME': 'fk_emp_dept',
-                    'child_table': 'dept_emp',
-                    'parent_table': 'employees',
-                }
-            ]
-        elif 'object_type' in sql:
-            return [
-                {'object_type': 'Tables', 'count': 6, 'names': 'employees,salaries,titles'},
-                {'object_type': 'Triggers', 'count': 0, 'names': 'None'},
-            ]
-        return []
+        return [{'error': 'Connection failed'}]
 
     monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_run_query', mock_mysql_run_query)
 
-    result = await analyze_schema('mysql', 'employees')
+    result = await analyze_source_db('mysql', 'employees', 30, 'database_identification')
 
-    assert 'Schema Analysis Results:' in result
-    assert 'Tables:' in result
-    assert 'employees' in result
+    assert 'Database Identification failed: Connection failed' in result
 
 
 @pytest.mark.asyncio
-async def test_analyze_unsupported_database(monkeypatch):
-    """Test analysis with unsupported database type."""
-    result = await analyze_access_patterns('postgresql', 'test_db', 30)
+async def test_analyze_source_db_unsupported_database():
+    """Test analyze_source_db with unsupported database type."""
+    result = await analyze_source_db('postgresql', 'test_db', 30, 'database_identification')
     assert 'Unsupported source database type: postgresql' in result
 
-    result = await analyze_schema('oracle', 'test_db')
+    result = await analyze_source_db('oracle', 'test_db', 30, 'table_analysis')
     assert 'Unsupported source database type: oracle' in result
-
-
-@pytest.mark.asyncio
-async def test_analyze_access_patterns_empty_results(mysql_env_setup, monkeypatch):
-    """Test access pattern analysis with empty query results."""
-
-    async def mock_mysql_run_query(sql, *args, **kwargs):
-        if 'performance_schema' in sql:
-            return [{'Variable_name': 'performance_schema', 'Value': 'ON'}]
-        return []  # Empty results
-
-    monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_run_query', mock_mysql_run_query)
-
-    result = await analyze_access_patterns('mysql', 'empty_db', 30)
-    assert 'Access Pattern Analysis Results:' in result
-    assert 'empty_db' in result
-
-
-@pytest.mark.asyncio
-async def test_analyze_schema_sql_error(mysql_env_setup, monkeypatch):
-    """Test schema analysis with SQL error."""
-
-    async def mock_mysql_run_query(sql, *args, **kwargs):
-        return [{'error': 'Table does not exist'}]
-
-    monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_run_query', mock_mysql_run_query)
-
-    result = await analyze_schema('mysql', 'nonexistent_db')
-    assert 'Table analysis failed: Table does not exist' in result
-
-
-@pytest.mark.asyncio
-async def test_analyze_access_patterns_invalid_parameters(mysql_env_setup, monkeypatch):
-    """Test access pattern analysis with invalid parameters."""
-
-    async def mock_mysql_run_query(sql, *args, **kwargs):
-        if 'performance_schema' in sql:
-            return [{'Variable_name': 'performance_schema', 'Value': 'ON'}]
-        return []
-
-    monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_run_query', mock_mysql_run_query)
-
-    # Test with zero days
-    result = await analyze_access_patterns('mysql', 'test_db', 0)
-    assert 'Access Pattern Analysis Results:' in result
-
-    # Test with negative days
-    result = await analyze_access_patterns('mysql', 'test_db', -5)
-    assert 'Access Pattern Analysis Results:' in result

--- a/src/dynamodb-mcp-server/tests/test_source_db_integration.py
+++ b/src/dynamodb-mcp-server/tests/test_source_db_integration.py
@@ -1,0 +1,65 @@
+import pytest
+from awslabs.dynamodb_mcp_server.database_analysis_queries import get_query_resource
+from awslabs.dynamodb_mcp_server.server import mysql_run_query
+
+
+@pytest.mark.asyncio
+async def test_mysql_connection_and_query(mysql_env_setup, mock_mysql_functions, monkeypatch):
+    """Test MySQL connection initialization and query execution."""
+    monkeypatch.setenv('MYSQL_READONLY', 'true')
+
+    result = await mysql_run_query('SELECT * FROM users')
+
+    assert result == [{'id': 1, 'name': 'test'}]
+
+
+@pytest.mark.asyncio
+async def test_mysql_missing_config(monkeypatch):
+    """Test MySQL query when configuration is missing."""
+    # Clear MySQL env vars using monkeypatch
+    monkeypatch.delenv('MYSQL_CLUSTER_ARN', raising=False)
+    monkeypatch.delenv('MYSQL_SECRET_ARN', raising=False)
+    monkeypatch.delenv('MYSQL_DATABASE', raising=False)
+
+    result = await mysql_run_query('SELECT * FROM users')
+    assert 'error' in result[0]
+    assert 'MySQL integration requires these environment variables' in result[0]['error']
+
+
+@pytest.mark.asyncio
+async def test_mysql_aws_region_fallback(mysql_env_setup, monkeypatch):
+    """Test MYSQL_AWS_REGION fallback to AWS_REGION."""
+    monkeypatch.setenv('AWS_REGION', 'us-east-1')  # Should fallback to this
+    monkeypatch.delenv('MYSQL_AWS_REGION', raising=False)
+
+    # Mock the MySQL functions
+    def mock_initialize(*args, **kwargs):
+        return True
+
+    async def mock_query(*args, **kwargs):
+        return [{'region': 'us-east-1'}]
+
+    monkeypatch.setattr(
+        'awslabs.dynamodb_mcp_server.server.DBConnectionSingleton.initialize', mock_initialize
+    )
+    monkeypatch.setattr('awslabs.dynamodb_mcp_server.server.mysql_query', mock_query)
+
+    result = await mysql_run_query("SELECT 'us-east-1' as region")
+    assert result == [{'region': 'us-east-1'}]
+
+
+def test_query_resource_functions():
+    """Test query resource utility functions."""
+    # Test getting a query resource
+    query = get_query_resource('performance_schema_check')
+    assert 'sql' in query
+    assert 'SHOW VARIABLES LIKE' in query['sql']
+
+    # Test parameter substitution
+    query = get_query_resource('pattern_analysis', target_database='employees', analysis_days=30)
+    assert 'employees' in query['sql']
+    assert '30' in query['sql']
+
+    # Test invalid query name
+    with pytest.raises(ValueError, match="Query 'invalid_query' not found"):
+        get_query_resource('invalid_query')

--- a/src/dynamodb-mcp-server/uv.lock
+++ b/src/dynamodb-mcp-server/uv.lock
@@ -197,6 +197,7 @@ name = "awslabs-dynamodb-mcp-server"
 version = "1.0.9"
 source = { editable = "." }
 dependencies = [
+    { name = "awslabs-mysql-mcp-server" },
     { name = "boto3" },
     { name = "dspy-ai" },
     { name = "loguru" },
@@ -222,6 +223,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "awslabs-mysql-mcp-server", specifier = ">=1.0.5" },
     { name = "boto3", specifier = "==1.40.5" },
     { name = "dspy-ai", specifier = ">=2.6.27" },
     { name = "loguru", specifier = "==0.7.3" },
@@ -243,6 +245,22 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "ruff", specifier = ">=0.9.7" },
+]
+
+[[package]]
+name = "awslabs-mysql-mcp-server"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "loguru" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/af/60684a88d3da7bdc0e03ae2af26dbad32f209146d4a519c0ab08582ed511/awslabs_mysql_mcp_server-1.0.5.tar.gz", hash = "sha256:a168c3bc63d5f215603041a510716509ab9192d89d463f5d44f92b4d9788ee5b", size = 85049, upload-time = "2025-08-21T18:29:43.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/a8/01b3171433594d4e0649757207cc25d1c0a8340d6a5a25dc6758265fd69c/awslabs_mysql_mcp_server-1.0.5-py3-none-any.whl", hash = "sha256:bd23fa850137d15d1b1aecf60ae49e546b73999e54563cd69b10f5d8be01aa11", size = 15042, upload-time = "2025-08-21T18:29:42.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Added comprehensive database analysis tools to the DynamoDB MCP Server for Data Modeling from MySQL to DynamoDB. This includes:

- New unified MCP tool: analyze_source_db for analyzing source MySQL databases with predefined query types.
- Comprehensive SQL queries for analyzing tables, columns, indexes, foreign keys, and access patterns through query names like 'database_identification', 'table_analysis', etc.
- MySQL connectivity and query capabilities are utilized from MySQL-MCP-SERVER package which is integrated with DYNAMODB-MCP-SERVER. Single MCP configuration handles both server connections.
- Updated documentation with MySQL integration setup instructions and workflow usage of the new tool.

### User experience

**Before**: Users had no built-in tools to analyze their existing MySQL databases when performing DynamoDB Data Modeling. They would need to manually inspect database schemas and guess at access patterns.

**After**: Users can now run analyze_source_db('mysql', 'database_name', analysis_days, 'query_name') to get detailed analysis reports including:
- Table structures, sizes, and row counts
- Column types and constraints
- Index usage and foreign key relationships  
- Query patterns and RPS (requests per second) analysis
- Performance schema setup guidance if not enabled
- Actionable insights for DynamoDB table design decisions

With these output, users can invoke DynamoDB data modeling tool to get the final data modeling file.

### Example conversation with Q CLI

### Success Tess

```
/help all commands  •  ctrl + j new lines  •  ctrl + s fuzzy search
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🤖 You are chatting with claude-3.7-sonnet

> analyse all my mysql database "employees" for last 60 days

> I'll analyze your MySQL "employees" database for the last 60 days. This will examine query patterns, performance metrics, and access patterns from the MySQL
Performance Schema.


🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "source_db_type": "mysql",
 ⋮      "target_database": "employees",
 ⋮      "query_name": "query_patterns",
 ⋮      "analysis_days": 60
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.8s


> Let me run the available analysis queries to get comprehensive insights about your employees database:


🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "analysis_days": 60,
 ⋮      "target_database": "employees",
 ⋮      "source_db_type": "mysql",
 ⋮      "query_name": "pattern_analysis"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.290s





🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "analysis_days": 60,
 ⋮      "target_database": "employees",
 ⋮      "source_db_type": "mysql",
 ⋮      "query_name": "rps_calculation"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.22s





🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "analysis_days": 60,
 ⋮      "target_database": "employees",
 ⋮      "source_db_type": "mysql",
 ⋮      "query_name": "table_analysis"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.26s





🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "analysis_days": 60,
 ⋮      "target_database": "employees",
 ⋮      "source_db_type": "mysql",
 ⋮      "query_name": "index_analysis"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.24s


> ## MySQL Database Analysis Summary - "employees" (60 days)

### Key Findings:

Database Scale:
• **Largest table**: salaries (2.8M rows, 121MB data)
• **Total data size**: ~173MB across 6 main tables
• **Peak RPS**: 670 requests per second

Query Patterns (Top Access Patterns):
1. Employee lookups by ID (71 queries) - Primary access pattern
2. Department employee counts (83 queries) - Aggregation pattern  
3. Salary queries by employee (67 queries) - Time-series access
4. Department name lookups (80 queries) - Reference data
5. Gender-based employee counts (72 queries) - Analytics pattern

Table Structure:
• salaries: 2.8M rows, time-series data (emp_no + from_date composite key)
• titles: 443K rows, employee title history
• dept_emp: 331K rows, employee-department relationships
• employees: 300K rows, core employee data
• departments: 9 rows, reference data
• dept_manager: 24 rows, management relationships

Access Patterns Identified:
• **Point lookups**: Employee by ID (emp_no)
• **Range queries**: Salary history by employee + date
• **Aggregations**: Department statistics, salary averages
• **Joins**: Multi-table employee details (employee + department + salary)
• **Analytics**: Gender distribution, hiring trends

Index Usage:
• Primary keys on all tables (composite keys for time-series data)
• Foreign key relationships between employees, departments, and time-series tables
• Unique constraint on department names

This analysis shows a classic HR database with strong relational patterns, time-series salary data, and frequent analytical queries - ideal for DynamoDB 
modeling with denormalization strategies.
```

### Edge cases

```
> can we analyze patterns for -1 days?

> I can't analyze patterns for -1 days as the analysis_days parameter requires a minimum value of 1. Let me run the analysis for 1 day instead:


🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "analysis_days": 1,
 ⋮      "target_database": "employees",
 ⋮      "source_db_type": "mysql",
 ⋮      "query_name": "pattern_analysis"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.360s


> The 1-day analysis shows minimal activity - only 38 schema queries, indicating very low recent activity in your employees database. The bulk of the 
operations we saw in the 30-day analysis were from earlier data loading and testing activities.

For meaningful pattern analysis, you'd need at least 1 day of actual application traffic. The negative value (-1) isn't supported by the analysis tool's 
validation.

> can you analyze for abc database?





🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "analysis_days": 30,
 ⋮      "target_database": "abc",
 ⋮      "source_db_type": "mysql",
 ⋮      "query_name": "pattern_analysis"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.34s


> The analysis for database "abc" returned no results, indicating either:

1. The database doesn't exist
2. No query activity has occurred in the past 30 days
3. Performance Schema wasn't capturing data for this database

The empty results suggest this database has no recorded query patterns to analyze for DynamoDB migration planning.

> can you show the configured db?




🛠️  Using tool: analyze_source_db from mcp server dynamodb-mcp-server-uv
 ⋮ 
 ● Running analyze_source_db with the param:
 ⋮  {
 ⋮    "name": "analyze_source_db",
 ⋮    "arguments": {
 ⋮      "analysis_days": 30,
 ⋮      "target_database": "employees",
 ⋮      "source_db_type": "mysql",
 ⋮      "query_name": "database_identification"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮ 
 ● Completed in 0.21s


> The configured database is employees. This is the database that your MySQL connection is currently set to analyze through the MCP server configuration.

> 
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): No

**RFC issue number**: N/A

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).